### PR TITLE
add new option to make basePath optional

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ program
   .arguments('<file>')
   .option('--validate', 'Validate the API')
   .option('--include-internal', 'Include Internal API calls')
+  .option('--no-basepath', 'do not add basePath to output')
   .action(function(file) {
     apiFilePath = file;
   });
@@ -31,7 +32,7 @@ if(program.validate) {
 
 SwaggerParser.bundle(apiFilePath)
   .then(function(api) {
-    openapi2slate.printSlateMarkdown(api, program.includeInternal);
+    openapi2slate.printSlateMarkdown(api, program);
   })
   .catch(function(err) {
     if (typeof err === 'object') {

--- a/openapi2slate.js
+++ b/openapi2slate.js
@@ -7,19 +7,19 @@ var definitions = require('./definitions.js');
 var paths = require('./paths.js');
 
 module.exports = {
-  printSlateMarkdown: function(api, includeInternal) {
+  printSlateMarkdown: function(api, program) {
     RefParser.dereference(api)
       .then(function(deRefApi) {
         // Info Section
         console.log(info.headerWithInfo(api, false));
         // Paths from dereferenced API
         var epPaths = paths.addEndpointToPaths(deRefApi.basePath, deRefApi.paths);
-        if(!includeInternal) {
+        if(!program.includeInternal) {
           epPaths = paths.filterInternalTag(epPaths);
         }
         var groupedEpPaths = paths.groupPathsByTag(epPaths);
-        console.log(paths.sectionIndexOfGroupedEndpointPaths(groupedEpPaths, includeInternal));
-        console.log(paths.sectionForGroupedEndpointPaths(groupedEpPaths, includeInternal));
+        console.log(paths.sectionIndexOfGroupedEndpointPaths(groupedEpPaths, program.includeInternal));
+        console.log(paths.sectionForGroupedEndpointPaths(groupedEpPaths, program.includeInternal));
         // Responses + Definitions
         console.log(responses.responsesSection(api.responses, 1));
         console.log(definitions.definitionsObject(api.definitions));

--- a/test/check/help
+++ b/test/check/help
@@ -3,4 +3,5 @@ Usage: main [options] <file>
 Options:
   --validate          Validate the API
   --include-internal  Include Internal API calls
+  --no-basepath       do not add basePath to output
   -h, --help          output usage information


### PR DESCRIPTION
basePath for us is forced by AWS API Gateway and only confuses the reader, we like to skip it