### PR TITLE
Fix array descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 test/output/
+/.log/
+/.envrc
+/.direnv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1]
+- Change description of arrays, so that instead of saying:
+
+  > The value of this array must match *at least one* of the following schemas
+
+  the description will say:
+
+  > Each element of this array must match *at least one* of the following
+  > schemas
+
 ## [1.3.0] - 2020-05-02
 - Add support for `const` schema attribute
 - Fixed inconsistent schema titles

--- a/json-schema-to-html/schema.js
+++ b/json-schema-to-html/schema.js
@@ -130,19 +130,19 @@ function renderItemsValidation(schema, type, octothorpes) {
 	var text = []
 	var validationItems = []
 
-	var content = schema.type == "array" ? "elements" : "value";
+	var content = type == "array" ? "Each element" : "The value";
 
 	if (schema.allOf) {
-		text.push(Markdown.render('The ' + content + ' of this ' + type + ' must match *all* of the following schemas:'))
+		text.push(Markdown.render(content + ' of this ' + type + ' must match *all* of the following schemas:'))
 		validationItems = schema.allOf
 	} else if (schema.anyOf) {
-		text.push(Markdown.render('The ' + content + ' of this ' + type + ' must match *at least one* of the following schemas:'))
+		text.push(Markdown.render(content + ' of this ' + type + ' must match *at least one* of the following schemas:'))
 		validationItems = schema.anyOf
 	} else if (schema.oneOf) {
-		text.push(Markdown.render('The ' + content + ' of this ' + type + ' must match *exactly one* of the following schemas:'))
+		text.push(Markdown.render(content + ' of this ' + type + ' must match *exactly one* of the following schemas:'))
 		validationItems = schema.oneOf
 	} else if (schema.not) {
-		text.push(Markdown.render('The ' + content + ' of this ' + type + ' must *not* match the following schemas:'))
+		text.push(Markdown.render(content + ' of this ' + type + ' must *not* match the following schemas:'))
 		validationItems = schema.not
 	}
 	if (validationItems.length > 0) {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+
+set -eux
 
 echo "Running comparison tests"
 
@@ -9,22 +11,22 @@ mkdir -p $output
 
 out=help
 echo "# $out matches"
-./main.js --help > $output/$out
+./main.js --help >$output/$out
 diff $check/$out $output/$out
 
 out=basic.md
 echo "# $out matches"
-./main.js $input/basic.yaml > $output/$out
+./main.js $input/basic.yaml >$output/$out
 diff $check/$out $output/$out
 
 out=scrive_api.md
 echo "# $out matches"
-./main.js $input/scrive-apidocs/scrive_api.yaml > $output/$out
+./main.js $input/scrive-apidocs/scrive_api.yaml >$output/$out
 diff $check/$out $output/$out
 
 out=scrive_api_internal.md
 echo "# $out matches"
-./main.js --include-internal $input/scrive-apidocs/scrive_api.yaml > $output/$out
+./main.js --include-internal $input/scrive-apidocs/scrive_api.yaml >$output/$out
 diff $check/$out $output/$out
 
 # TODO add more example conversions

--- a/test/check/scrive_api.md
+++ b/test/check/scrive_api.md
@@ -5416,7 +5416,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h6> SignatoryFieldName <code>(object)</code> </h6>
@@ -10001,7 +10001,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h6> SignatoryFieldName <code>(object)</code> </h6>
@@ -13461,7 +13461,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h4> SignatoryFieldName <code>(object)</code> </h4>
@@ -18276,7 +18276,7 @@ custom regular expression.</p>
 
 <p>Default: <br/><code class="code-block">[]</code></p>
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> Filter by status <code>(object)</code> </h3>
@@ -18800,7 +18800,7 @@ document author.</p>
 <p>Attachments that have been added to a document by the author.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> <code>(object)</code> </h3>
@@ -19129,7 +19129,7 @@ documents.</p>
 
 <p>Default: <br/><code class="code-block">[]</code></p>
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> Filter by text <code>(object)</code> </h3>

--- a/test/check/scrive_api_internal.md
+++ b/test/check/scrive_api_internal.md
@@ -5869,7 +5869,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h6> SignatoryFieldName <code>(object)</code> </h6>
@@ -10454,7 +10454,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h6> SignatoryFieldName <code>(object)</code> </h6>
@@ -13914,7 +13914,7 @@ Similarly, a single field can have multiple placements on the document.</p>
 <p><strong>Note:</strong> Some field types have <em>no effect</em> without at least one placement.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h4> SignatoryFieldName <code>(object)</code> </h4>
@@ -18729,7 +18729,7 @@ custom regular expression.</p>
 
 <p>Default: <br/><code class="code-block">[]</code></p>
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> Filter by status <code>(object)</code> </h3>
@@ -19253,7 +19253,7 @@ document author.</p>
 <p>Attachments that have been added to a document by the author.</p>
 
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> <code>(object)</code> </h3>
@@ -19582,7 +19582,7 @@ documents.</p>
 
 <p>Default: <br/><code class="code-block">[]</code></p>
 
-<p>The value of this array must match <em>at least one</em> of the following schemas:</p>
+<p>Each element of this array must match <em>at least one</em> of the following schemas:</p>
 
 
 <h3> Filter by text <code>(object)</code> </h3>


### PR DESCRIPTION
Instead of saying "The value of this array must match *at least one* of the following schemas", the description will say "Each element of this array must match *at least one* of the following schemas".